### PR TITLE
Fix dark text color in bookmark toolbar

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -50,7 +50,7 @@
         54,
         57
       ],
-      "rookmark_text": [
+      "bookmark_text": [
         241,
         243,
         244


### PR DESCRIPTION
I have a following issue with a theme: bookmarks on bookmark panel have dark font and are barely visible. IIUC it's caused by a typo ('rookmark' -> 'bookmark').

Before:
![image](https://user-images.githubusercontent.com/5783792/96998614-6c0dd900-153c-11eb-9dae-b41ee53c185a.png)

After:
![image](https://user-images.githubusercontent.com/5783792/96998689-9364a600-153c-11eb-8702-ca48ed4eb0da.png)